### PR TITLE
增加macOS支持

### DIFF
--- a/ADBShell.py
+++ b/ADBShell.py
@@ -8,7 +8,6 @@ from random import randint
 
 class ADBShell(object):
     def __init__(self, adb_host=ADB_HOST):
-        self.SCREEN_SHOOT_SAVE_PATH = os.path.abspath(SCREEN_SHOOT_SAVE_PATH) + "\\"
         # os.chdir(ADB_ROOT)
         self.ADB_ROOT = ADB_ROOT
         self.ADB_HOST = adb_host
@@ -17,13 +16,21 @@ class ADBShell(object):
         self.__adb_tools = ""
         self.__adb_command = ""
         self.DEVICE_NAME = self.__adb_device_name_detector()
-        self.__command = "\"" + self.ADB_ROOT + "\\adb.exe\" -s " + self.DEVICE_NAME + " {tools} {command} "
+        if "win32" in os.sys.platform:
+            self.__command = "\"" + self.ADB_ROOT + "\\adb.exe\" -s " + self.DEVICE_NAME + " {tools} {command} "
+            self.SCREEN_SHOOT_SAVE_PATH = os.path.abspath(SCREEN_SHOOT_SAVE_PATH) + "\\"
+        else:
+            self.__command = self.ADB_ROOT + "/adb -s "+ self.DEVICE_NAME + " {tools} {command} "
+            self.SCREEN_SHOOT_SAVE_PATH = os.path.abspath(SCREEN_SHOOT_SAVE_PATH) + "/"
         # 命令格式 "D:\Program Files\Nox\bin\adb.exe" -s 127.0.0.1:62001 shell am start ...
         # Linux 和 Mac 机器我不太清楚咋整. 不过好像大家目前还没这个需求
         # self.__adb_connect()
 
     def __adb_device_name_detector(self):
-        self.__command = "\"" + self.ADB_ROOT + "\\adb.exe\" {tools} {command}"
+        if "win32" in os.sys.platform:
+            self.__command = "\"" + self.ADB_ROOT + "\\adb.exe\" {tools} {command}"
+        else:
+            self.__command = self.ADB_ROOT + "/adb {tools} {command}"
         self.__adb_tools = "devices"
         content = self.run_cmd(DEBUG_LEVEL=1).strip().split("\n")
         content.pop(0)

--- a/Arknights/base.py
+++ b/Arknights/base.py
@@ -29,7 +29,7 @@ class ArknightsHelper(object):
         self.shell_color = ShellColor() if out_put == 0 else BufferColor()
         self.__is_game_active = False
         self.__call_by_gui = call_by_gui
-        self.__rebase_to_null = " 1>nul 2>nul" if "win" in os.sys.platform else " 1>/dev/null 2>/dev/null &" \
+        self.__rebase_to_null = " 1>nul 2>nul" if "win32" in os.sys.platform else " 1>/dev/null 2>/dev/null &" \
             if enable_rebase_to_null else ""
         self.CURRENT_STRENGTH = 100
         self.selector = BattleSelector()
@@ -103,6 +103,7 @@ class ArknightsHelper(object):
                         else:
                             return False
         except Exception as e:
+            print(e)
             self.shell_color.failure_text("[!] OCR 模块未检测...装载初始理智值")
             if current_strength is not None:
                 self.CURRENT_STRENGTH = current_strength

--- a/Arknights/base.py
+++ b/Arknights/base.py
@@ -103,7 +103,6 @@ class ArknightsHelper(object):
                         else:
                             return False
         except Exception as e:
-            print(e)
             self.shell_color.failure_text("[!] OCR 模块未检测...装载初始理智值")
             if current_strength is not None:
                 self.CURRENT_STRENGTH = current_strength

--- a/config/common_config.py
+++ b/config/common_config.py
@@ -1,4 +1,7 @@
 import os
-
-SCREEN_SHOOT_SAVE_PATH = os.getcwd() + "\\screen_shoot\\"
-STORAGE_PATH = os.getcwd() + "\\storage\\"
+if "win32" in os.sys.platform:
+    SCREEN_SHOOT_SAVE_PATH = os.getcwd() + "\\screen_shoot\\"
+    STORAGE_PATH = os.getcwd() + "\\storage\\"
+else:
+    SCREEN_SHOOT_SAVE_PATH = os.getcwd() + "/screen_shoot/"
+    STORAGE_PATH = os.getcwd() + "/storage/"


### PR DESCRIPTION
增加macOS支持
- [x] 测试系统 macOS Mojave 10.14现在起可运行
- [x] 已回到Windows平台验证可用性

(Tip: 建议使用`win32`限定Windows平台，若使用`win`判断在macOS下`os.sys.platform`的值`darwin`将导致本可跨平台的代码挂掉)
