### PR TITLE
修复满级后风笛背景干扰掉落物分组识别的问题

### DIFF
--- a/create_plan_by_item.py
+++ b/create_plan_by_item.py
@@ -29,8 +29,8 @@ if __name__ == '__main__':
     owned = {}
     c = input('是否获取当前库存材料数量(y,N):')
     if c.lower() == 'y':
-        from Arknights.helper import ArknightsHelper
-        owned = ArknightsHelper().get_inventory_items()
+        from Arknights.shell_next import _create_helper
+        owned = _create_helper()[0].get_inventory_items()
     print('正在获取刷图计划...')
     plan = arkplanner.get_plan(required, owned)
     main_stage_map = arkplanner.get_main_stage_map()

--- a/grass_on_aog.py
+++ b/grass_on_aog.py
@@ -1,4 +1,4 @@
-from Arknights.helper import ArknightsHelper
+from Arknights.shell_next import _create_helper
 from penguin_stats import arkplanner
 import requests
 from datetime import datetime
@@ -67,7 +67,7 @@ headers = {
     'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
 }
 aog_cache = load_aog_cache()
-helper = ArknightsHelper()
+helper, _ = _create_helper()
 
 
 def load_inventory():

--- a/imgreco/end_operation.py
+++ b/imgreco/end_operation.py
@@ -214,7 +214,7 @@ def recognize(im):
     x, y = 6.667 * vh, 18.519 * vh
     linedet = items.crop((x, y, x + 1, items.height)).convert('L')
     d = np.asarray(linedet)
-    linedet = find_jumping(d.reshape(linedet.height), 64)
+    linedet = find_jumping(d.reshape(linedet.height), 55)
     if len(linedet) >= 2:
         linetop, linebottom, *_ = linedet
     else:
@@ -231,7 +231,7 @@ def recognize(im):
     logger.logimage(grouping.resize((grouping.width, 16)))
 
     d = np.array(grouping, dtype=np.int16)[0]
-    points = [0, *find_jumping(d, 64)]
+    points = [0, *find_jumping(d, 55)]
     if len(points) % 2 != 0:
         raise RuntimeError('possibly incomplete item list')
     finalgroups = list(zip(*[iter(points)] * 2))  # each_slice(2)

--- a/run_plan.py
+++ b/run_plan.py
@@ -1,4 +1,5 @@
-from Arknights.helper import ArknightsHelper, logger
+from Arknights.helper import logger
+from Arknights.shell_next import _create_helper
 import config
 import json
 import os
@@ -10,7 +11,7 @@ if __name__ == '__main__':
         exit(-1)
     with open('config/plan.json', 'r') as f:
         plan = json.load(f)
-    helper = ArknightsHelper()
+    helper, _ = _create_helper()
     if plan['stages']:
         update_flag = False
         has_remain_sanity = True


### PR DESCRIPTION
满级后精二风笛背景会干扰掉落物分组识别, 所以调了一下 find_jumping 的阈值
![test1.png](https://i.loli.net/2021/04/30/1wKSF3cIt2MXT7f.png)
![test3.png](https://i.loli.net/2021/04/30/dG6wt23S7qk5v9B.png)