### PR TITLE
Refine line ending issue in Windows batch files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Windows-style newlines with a newline ending every batch file
+[*.bat]
+end_of_line = crlf
+insert_final_newline = true
+charset = utf-8

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 *.dat binary
 *.onnx binary
+
+*.bat text eol=crlf
+*.cmd text eol=crlf


### PR DESCRIPTION
`git`如果启用了`autocrlf`会对`.bat`的批处理文件的换行符产生问题导致不能正确执行，所以这里准备直接新建一个`.editorconfig`，`clone`下来后可以一劳永逸。