### PR TITLE
Fix import missing for high Python version

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -6,7 +6,11 @@ import logging.config
 import os
 import shutil
 import sys
-from collections import Mapping
+
+if sys.version_info[:2] >= (3, 8):
+    from collections.abc import Mapping
+else:
+    from collections import Mapping
 
 import ruamel.yaml
 


### PR DESCRIPTION
`Mapping` module has been moved under `collections.abc` after Python 3.9 and higher version.