### PR TITLE
企鹅物流增加家具上报&公招识别异常时输出日志

### DIFF
--- a/Arknights/addons/recruit.py
+++ b/Arknights/addons/recruit.py
@@ -9,6 +9,8 @@ class RecruitAddon(AddonBase):
         self.logger.info('识别招募标签')
         tags = imgreco.recruit.get_recruit_tags(self.device.screenshot())
         self.logger.info('可选标签：%s', ' '.join(tags))
+        if len(tags) != 5:
+            self.logger.warning('识别到的标签数量异常，一共识别了%d个标签', len(tags))
         result = recruit_calc.calculate(tags)
         self.logger.debug('计算结果：%s', repr(result))
         return result

--- a/resources/event.py
+++ b/resources/event.py
@@ -37,7 +37,7 @@ FIXED_QUANTITY = [
 #     '感谢庆典物资补给',
 # ]
 
-report_types = {'MATERIAL', 'CARD_EXP', 'VOUCHER_MGACHA', 'special_report_item'}
+report_types = {'MATERIAL', 'CARD_EXP', 'VOUCHER_MGACHA', 'furni', 'special_report_item'}
 
 
 def event_preprocess(stage: str, items: List[Tuple[str, str, int, str]], exclude_from_validation: List):


### PR DESCRIPTION
原来有几次出了家具但是企鹅物流那边没有家具的上报数据
修改后已验证可以上报家具数据了(其实很早就改好了但是我脸太黑了到今天才再次刷出家具确认了现在能够正常上报)

公招在识别数量不为5的时候增加了一条警告提示信息