### PR TITLE
Fix: PosixPath object has no attribute encode

### DIFF
--- a/imgreco/ocr/tesseract/tessbaseapi.py
+++ b/imgreco/ocr/tesseract/tessbaseapi.py
@@ -96,7 +96,7 @@ class BaseAPI:
             if self.fsencoding == 'mbcs':
                 datapath = encode_mbcs_path(datapath)
             else:
-                datapath = datapath.encode(self.fsencoding)
+                datapath = str(datapath).encode(self.fsencoding)
         if configs is not None:
             configlen = len(configs)
             configsarr = (ctypes.c_char_p * configlen)()


### PR DESCRIPTION
Convert PosixPath object to string first then encode with self.fsencoding.
Only tested under Linux.