### PR TITLE
recruit: convert new tier format to digit

### DIFF
--- a/resources/recruit_database.py
+++ b/resources/recruit_database.py
@@ -184,6 +184,7 @@ def get_recruit_database_by_game_data():
         tag_list = [profession_map.get(character['profession'])]
         tag_list += position_map.get(character['position'], [])
         tag_list += character['tagList']
+        character['rarity'] = int(character['rarity'][5]) - 1
         # print((character_name, character['rarity'], tag_list))
         if character['rarity'] == 0:
             tag_list.append('支援机械')


### PR DESCRIPTION
公招使用自动更新的数据。其中，干员的星级从数字变成了 `TIER_1` 这样的格式，导致公招功能失效了。对此字段的数据进行格式转换，即可解决此问题。